### PR TITLE
Fix bug when spaces exist in path for key file passed into forward-local-ports

### DIFF
--- a/forward-local-ports
+++ b/forward-local-ports
@@ -55,7 +55,7 @@ printf "%5s %s\n" ${HUE_PORT} "Hue HTTP"
 printf "%5s %s\n" ${RESMGR_PORT} "Resource Manager HTTP"
 printf "%5s %s\n" ${NAMENODE_PORT} "Name Node HTTP"
 
-$(dirname $0)/ssh-to-master $* -N \
+$(dirname $0)/ssh-to-master "$@" -N \
  -L${DRILL_UI_PORT}:${PRIVATE_ADDR}:${DRILL_UI_PORT} \
  -L${DRILL_USER_PORT}:${PRIVATE_ADDR}:${DRILL_USER_PORT} \
  -L${ZOOKEEPER_PORT}:${PRIVATE_ADDR}:${ZOOKEEPER_PORT} \


### PR DESCRIPTION
Pass arguments to ssh-to-master command as they were passed into forward-local-ports; particularly around treatment of spaces in original argument list. See http://stackoverflow.com/questions/255898/how-to-iterate-over-arguments-in-bash-script